### PR TITLE
[NEW] Mixed visibility for poll responses

### DIFF
--- a/PollApp.ts
+++ b/PollApp.ts
@@ -31,10 +31,10 @@ export class PollApp extends App implements IUIKitInteractionHandler {
     public async executeViewSubmitHandler(context: UIKitViewSubmitInteractionContext, read: IRead, http: IHttp, persistence: IPersistence, modify: IModify) {
         const data = context.getInteractionData();
 
-        const title = data.view.title.text;
+        const id = data.view.id;
 
-        switch (title) {
-            case 'Create a poll': {
+        if (/create-poll-modal/i.test(id)) {
+
                 const { state }: {
                     state: {
                         poll: {
@@ -87,9 +87,8 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                 return {
                     success: true,
                 };
-            }
+            } else if (/create-mixed-visibility-modal/.test(id)) {
 
-            case 'Select anonymous options': {
                 const { state }: {
                     state: {
                         mixedVisibility: {
@@ -120,8 +119,6 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                     success: true,
                 };
             }
-
-        }
 
         return {
             success: true,

--- a/PollApp.ts
+++ b/PollApp.ts
@@ -15,12 +15,13 @@ import {
     UIKitViewSubmitInteractionContext,
 } from '@rocket.chat/apps-engine/definition/uikit';
 
+import { pollVisibility } from './src/definition';
+import { createMixedVisibilityModal } from './src/lib/createMixedVisibilityModal';
 import { createPollMessage } from './src/lib/createPollMessage';
 import { createPollModal } from './src/lib/createPollModal';
 import { finishPollMessage } from './src/lib/finishPollMessage';
 import { votePoll } from './src/lib/votePoll';
 import { PollCommand } from './src/PollCommand';
-import { createMixedVisibilityModal } from './src/lib/createMixedVisibilityModal';
 export class PollApp extends App implements IUIKitInteractionHandler {
 
     constructor(info: IAppInfo, logger: ILogger) {
@@ -32,7 +33,7 @@ export class PollApp extends App implements IUIKitInteractionHandler {
 
         const title = data.view.title.text;
 
-        switch(title) {
+        switch (title) {
             case 'Create a poll': {
                 const { state }: {
                     state: {
@@ -46,7 +47,7 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                         },
                     },
                 } = data.view as any;
-        
+
                 if (!state) {
                     return context.getInteractionResponder().viewErrorResponse({
                         viewId: data.view.id,
@@ -56,7 +57,7 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                     });
                 }
 
-                if(state.config && state.config.visibility != "mixed") {
+                if (state.config && state.config.visibility !== pollVisibility.mixed) {
                     try {
                         await createPollMessage(data, read, modify, persistence, data.user.id);
                     } catch (err) {
@@ -65,13 +66,12 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                             errors: err,
                         });
                     }
-                }
-                else {
-                    //Open mixed visibility modal
+                } else {
+                    // Open mixed visibility modal
                     try {
                         const modal = await createMixedVisibilityModal({ question: state.poll.question, persistence, modify, data });
                         await modify.getUiController().openModalView(modal, context.getInteractionData(), data.user);
-                        
+
                         return {
                             success: true,
                         };
@@ -83,7 +83,7 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                         });
                     }
                 }
-        
+
                 return {
                     success: true,
                 };
@@ -93,8 +93,8 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                 const { state }: {
                     state: {
                         mixedVisibility: {
-                        anonymousOptions: any
-                        }
+                        anonymousOptions: any,
+                        },
                     },
                 } = data.view as any;
 
@@ -115,7 +115,7 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                         errors: err,
                     });
                 }
-        
+
                 return {
                     success: true,
                 };

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -16,8 +16,9 @@ export interface IPoll {
     totalVotes: number;
     votes: Array<IVoter>;
     finished?: boolean;
-    confidential?: boolean;
+    visibility?: string;
     singleChoice?: boolean;
+    anonymousOptions: Array<string>
 }
 
 export interface IModalContext extends Partial<IUIKitBlockIncomingInteraction> {

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,6 +1,12 @@
 import { IUIKitBlockIncomingInteraction } from '@rocket.chat/apps-engine/definition/uikit/UIKitIncomingInteractionTypes';
 import { IUser } from '@rocket.chat/apps-engine/definition/users';
 
+export enum pollVisibility {
+    open = 'open',
+    confidential = 'confidential',
+    mixed = 'mixed',
+}
+
 export type IVoterPerson = Pick<IUser, 'id' | 'username' | 'name'>;
 
 export interface IVoter {
@@ -16,9 +22,9 @@ export interface IPoll {
     totalVotes: number;
     votes: Array<IVoter>;
     finished?: boolean;
-    visibility?: string;
+    visibility?: pollVisibility;
     singleChoice?: boolean;
-    anonymousOptions: Array<string>
+    anonymousOptions: Array<string>;
 }
 
 export interface IModalContext extends Partial<IUIKitBlockIncomingInteraction> {

--- a/src/lib/buildVoteGraph.ts
+++ b/src/lib/buildVoteGraph.ts
@@ -11,7 +11,7 @@ const format = (num) => new Intl.NumberFormat('en-US', {
 export function buildVoteGraph(votes: IVoter, totalVotes: IPoll['totalVotes'], maxVoteIndex: boolean) {
     const percent = totalVotes === 0 ? 0 : votes.quantity / totalVotes;
 
-    const filled = maxVoteIndex ? '🟦': '⬛';
+    const filled = maxVoteIndex ? '🟦' : '⬛';
 
     const graphFilled = filled.repeat(Math.floor(percent * width));
     const graphEmpty = empty.repeat(width - Math.floor(percent * width));

--- a/src/lib/buildVoters.ts
+++ b/src/lib/buildVoters.ts
@@ -3,7 +3,7 @@ import { IVoter } from '../definition';
 const votersNames = (voters: IVoter['voters'], showNames: boolean) =>
     voters.map(({ name, username }) => showNames ? name : username).join(' ');
 
-export function buildVoters(votes: IVoter, showNames: boolean) {
+export function buildVoters(votes: IVoter, showNames: boolean, anonymous: boolean) {
     if (!votes) {
         return '';
     }
@@ -14,5 +14,5 @@ export function buildVoters(votes: IVoter, showNames: boolean) {
 
     const votesStr = votes.quantity === 1 ? 'vote' : 'votes';
 
-    return `${ votes.quantity } ${ votesStr } - ${ votersNames(votes.voters, showNames) }`;
+    return `${ votes.quantity } ${ votesStr } - ${ anonymous? "Anonymous" : votersNames(votes.voters, showNames) }`;
 }

--- a/src/lib/buildVoters.ts
+++ b/src/lib/buildVoters.ts
@@ -14,5 +14,5 @@ export function buildVoters(votes: IVoter, showNames: boolean, anonymous: boolea
 
     const votesStr = votes.quantity === 1 ? 'vote' : 'votes';
 
-    return `${ votes.quantity } ${ votesStr } - ${ anonymous? "Anonymous" : votersNames(votes.voters, showNames) }`;
+    return `${ votes.quantity } ${ votesStr } - ${ anonymous ? 'Anonymous' : votersNames(votes.voters, showNames) }`;
 }

--- a/src/lib/createMixedVisibilityModal.ts
+++ b/src/lib/createMixedVisibilityModal.ts
@@ -1,0 +1,81 @@
+import {
+    IModify,
+    IPersistence,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from "@rocket.chat/apps-engine/definition/metadata";
+import { IUIKitModalViewParam } from "@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder";
+
+import { uuid } from "./uuid";
+import { IUIKitViewSubmitIncomingInteraction } from "@rocket.chat/apps-engine/definition/uikit/UIKitIncomingInteractionTypes";
+
+export async function createMixedVisibilityModal({
+    id = "",
+    question,
+    persistence,
+    data,
+    modify,
+}: {
+    id?: string;
+    question?: string;
+    persistence: IPersistence;
+    data: IUIKitViewSubmitIncomingInteraction;
+    modify: IModify;
+}): Promise<IUIKitModalViewParam> {
+    const viewId = id || uuid();
+
+    const association = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.MISC,
+        viewId
+    );
+    await persistence.createWithAssociation(data, association);
+
+    const {
+        state,
+    }: {
+        state?: any;
+    } = data.view;
+
+    const options = Object.entries<any>(state.poll || {})
+        .filter(([key]) => key !== "question")
+        .map(([, option]) => option)
+        .filter((option) => option.trim() !== "");
+
+    const block = modify.getCreator().getBlockBuilder();
+    block.addSectionBlock({
+        text: block.newMarkdownTextObject(question ? question : ""),
+    });
+
+    block
+        .addActionsBlock({
+            blockId: "mixedVisibility",
+            elements: [
+                block.newMultiStaticElement({
+                    placeholder: block.newPlainTextObject("Multiple choices"),
+                    actionId: "anonymousOptions",
+                    options: options.map((option) => {
+                        return {
+                            text: block.newPlainTextObject(option),
+                            value: option,
+                        };
+                    }),
+                }),
+            ],
+        })
+
+        .addDividerBlock();
+
+    return {
+        id: viewId,
+        title: block.newPlainTextObject("Select anonymous options"),
+        submit: block.newButtonElement({
+            text: block.newPlainTextObject("Create"),
+        }),
+        close: block.newButtonElement({
+            text: block.newPlainTextObject("Dismiss"),
+        }),
+        blocks: block.getBlocks(),
+    };
+}

--- a/src/lib/createMixedVisibilityModal.ts
+++ b/src/lib/createMixedVisibilityModal.ts
@@ -1,18 +1,18 @@
 import {
     IModify,
     IPersistence,
-} from "@rocket.chat/apps-engine/definition/accessors";
+} from '@rocket.chat/apps-engine/definition/accessors';
 import {
     RocketChatAssociationModel,
     RocketChatAssociationRecord,
-} from "@rocket.chat/apps-engine/definition/metadata";
-import { IUIKitModalViewParam } from "@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder";
+} from '@rocket.chat/apps-engine/definition/metadata';
+import { IUIKitModalViewParam } from '@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder';
 
-import { uuid } from "./uuid";
-import { IUIKitViewSubmitIncomingInteraction } from "@rocket.chat/apps-engine/definition/uikit/UIKitIncomingInteractionTypes";
+import { IUIKitViewSubmitIncomingInteraction } from '@rocket.chat/apps-engine/definition/uikit/UIKitIncomingInteractionTypes';
+import { uuid } from './uuid';
 
 export async function createMixedVisibilityModal({
-    id = "",
+    id = '',
     question,
     persistence,
     data,
@@ -28,7 +28,7 @@ export async function createMixedVisibilityModal({
 
     const association = new RocketChatAssociationRecord(
         RocketChatAssociationModel.MISC,
-        viewId
+        viewId,
     );
     await persistence.createWithAssociation(data, association);
 
@@ -39,22 +39,22 @@ export async function createMixedVisibilityModal({
     } = data.view;
 
     const options = Object.entries<any>(state.poll || {})
-        .filter(([key]) => key !== "question")
+        .filter(([key]) => key !== 'question')
         .map(([, option]) => option)
-        .filter((option) => option.trim() !== "");
+        .filter((option) => option.trim() !== '');
 
     const block = modify.getCreator().getBlockBuilder();
     block.addSectionBlock({
-        text: block.newMarkdownTextObject(question ? question : ""),
+        text: block.newMarkdownTextObject(question ? question : ''),
     });
 
     block
         .addActionsBlock({
-            blockId: "mixedVisibility",
+            blockId: 'mixedVisibility',
             elements: [
                 block.newMultiStaticElement({
-                    placeholder: block.newPlainTextObject("Multiple choices"),
-                    actionId: "anonymousOptions",
+                    placeholder: block.newPlainTextObject('Multiple choices'),
+                    actionId: 'anonymousOptions',
                     options: options.map((option) => {
                         return {
                             text: block.newPlainTextObject(option),
@@ -69,12 +69,12 @@ export async function createMixedVisibilityModal({
 
     return {
         id: viewId,
-        title: block.newPlainTextObject("Select anonymous options"),
+        title: block.newPlainTextObject('Select anonymous options'),
         submit: block.newButtonElement({
-            text: block.newPlainTextObject("Create"),
+            text: block.newPlainTextObject('Create'),
         }),
         close: block.newButtonElement({
-            text: block.newPlainTextObject("Dismiss"),
+            text: block.newPlainTextObject('Dismiss'),
         }),
         blocks: block.getBlocks(),
     };

--- a/src/lib/createMixedVisibilityModal.ts
+++ b/src/lib/createMixedVisibilityModal.ts
@@ -24,7 +24,7 @@ export async function createMixedVisibilityModal({
     data: IUIKitViewSubmitIncomingInteraction;
     modify: IModify;
 }): Promise<IUIKitModalViewParam> {
-    const viewId = id || uuid();
+    const viewId = id || `create-mixed-visibility-modal-${uuid()}`;
 
     const association = new RocketChatAssociationRecord(
         RocketChatAssociationModel.MISC,

--- a/src/lib/createPollBlocks.ts
+++ b/src/lib/createPollBlocks.ts
@@ -67,12 +67,7 @@ export function createPollBlocks(block: BlockBuilder, question: string, options:
         if (poll.visibility === "confidential") {
             return;
         }
-
-        if(anonymousOptions.includes(poll.options[index])) {
-            return;
-        }
-
-        const voters = buildVoters(poll.votes[index], showNames);
+        const voters = buildVoters(poll.votes[index], showNames, anonymousOptions.includes(poll.options[index]));
         if (!voters) {
             return;
         }

--- a/src/lib/createPollBlocks.ts
+++ b/src/lib/createPollBlocks.ts
@@ -4,7 +4,7 @@ import { IPoll } from '../definition';
 import { buildVoteGraph } from './buildVoteGraph';
 import { buildVoters } from './buildVoters';
 
-export function createPollBlocks(block: BlockBuilder, question: string, options: Array<any>, poll: IPoll, showNames: boolean) {
+export function createPollBlocks(block: BlockBuilder, question: string, options: Array<any>, poll: IPoll, showNames: boolean, anonymousOptions: Array<string>) {
     block.addSectionBlock({
         text: block.newPlainTextObject(question),
         ...!poll.finished && {
@@ -64,7 +64,11 @@ export function createPollBlocks(block: BlockBuilder, question: string, options:
             ],
         });
 
-        if (poll.confidential) {
+        if (poll.visibility === "confidential") {
+            return;
+        }
+
+        if(anonymousOptions.includes(poll.options[index])) {
             return;
         }
 

--- a/src/lib/createPollBlocks.ts
+++ b/src/lib/createPollBlocks.ts
@@ -1,6 +1,6 @@
 import { BlockBuilder, BlockElementType } from '@rocket.chat/apps-engine/definition/uikit';
 
-import { IPoll } from '../definition';
+import { IPoll, pollVisibility } from '../definition';
 import { buildVoteGraph } from './buildVoteGraph';
 import { buildVoters } from './buildVoters';
 
@@ -31,13 +31,14 @@ export function createPollBlocks(block: BlockBuilder, question: string, options:
 
     block.addDividerBlock();
 
-    const maxVoteQuantity = Math.max(...poll.votes.map(vote => vote.quantity))
+    const maxVoteQuantity = Math.max(...poll.votes.map((vote) => vote.quantity));
     // Forms array of option indices with maximum votes (more than 1 option can be max-voted)
     const maxVoteIndices = poll.votes
-        .map(vote => vote.quantity)
-        .reduce((ind: number[], el, i) => {
-            if (el === maxVoteQuantity)
+        .map((vote) => vote.quantity)
+        .reduce((ind: Array<number>, el, i) => {
+            if (el === maxVoteQuantity) {
                 ind.push(i);
+            }
             return ind;
         }, []);
     options.forEach((option, index) => {
@@ -64,7 +65,7 @@ export function createPollBlocks(block: BlockBuilder, question: string, options:
             ],
         });
 
-        if (poll.visibility === "confidential") {
+        if (poll.visibility === pollVisibility.confidential) {
             return;
         }
         const voters = buildVoters(poll.votes[index], showNames, anonymousOptions.includes(poll.options[index]));

--- a/src/lib/createPollMessage.ts
+++ b/src/lib/createPollMessage.ts
@@ -4,28 +4,28 @@ import {
     IUIKitViewSubmitIncomingInteraction,
 } from '@rocket.chat/apps-engine/definition/uikit/UIKitIncomingInteractionTypes';
 
-import { IModalContext, IPoll } from '../definition';
+import { IModalContext, IPoll, pollVisibility } from '../definition';
 import { createPollBlocks } from './createPollBlocks';
 
 export async function createPollMessage(data: IUIKitViewSubmitIncomingInteraction, read: IRead, modify: IModify, persistence: IPersistence, uid: string) {
     const { view: { id } } = data;
-    var { state }: {
+    let { state }: {
         state?: any;
     } = data.view;
 
     const association = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, id);
     const [record] = await read.getPersistenceReader().readByAssociation(association) as Array<IModalContext>;
-    var anonymousOptions = []
+    let anonymousOptions = [];
 
     // When createPollMessage is called from mixed visibility modal case
     // the second-last view id contains slashcommand data
-    if((record as IUIKitViewSubmitIncomingInteraction).view) {
+    if ((record as IUIKitViewSubmitIncomingInteraction).view) {
         const testAssociation = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, (record as IUIKitViewSubmitIncomingInteraction).view.id);
         const [test] = await read.getPersistenceReader().readByAssociation(testAssociation) as Array<IModalContext>;
         record.threadId = test.threadId;
         record.room = test.room;
         // Extract anonymous options before state is modified
-        anonymousOptions = state.mixedVisibility.anonymousOptions
+        anonymousOptions = state.mixedVisibility.anonymousOptions;
         state = (record as IUIKitViewSubmitIncomingInteraction).view.state;
     }
 
@@ -63,8 +63,8 @@ export async function createPollMessage(data: IUIKitViewSubmitIncomingInteractio
     }
 
     try {
-        const { config = { mode: 'multiple', visibility: 'open' } } = state;
-        const { mode = 'multiple', visibility = 'open' } = config;
+        const { config = { mode: 'multiple', visibility: pollVisibility.open } } = state;
+        const { mode = 'multiple', visibility = pollVisibility.open } = config;
 
         const showNames = await read.getEnvironmentReader().getSettings().getById('use-user-name');
 
@@ -85,9 +85,9 @@ export async function createPollMessage(data: IUIKitViewSubmitIncomingInteractio
             options,
             totalVotes: 0,
             votes: options.map(() => ({ quantity: 0, voters: [] })),
-            visibility: visibility,
+            visibility,
             singleChoice: mode === 'single',
-            anonymousOptions
+            anonymousOptions,
         };
 
         const block = modify.getCreator().getBlockBuilder();

--- a/src/lib/createPollMessage.ts
+++ b/src/lib/createPollMessage.ts
@@ -9,12 +9,25 @@ import { createPollBlocks } from './createPollBlocks';
 
 export async function createPollMessage(data: IUIKitViewSubmitIncomingInteraction, read: IRead, modify: IModify, persistence: IPersistence, uid: string) {
     const { view: { id } } = data;
-    const { state }: {
+    var { state }: {
         state?: any;
     } = data.view;
 
     const association = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, id);
     const [record] = await read.getPersistenceReader().readByAssociation(association) as Array<IModalContext>;
+    var anonymousOptions = []
+
+    // When createPollMessage is called from mixed visibility modal case
+    // the second-last view id contains slashcommand data
+    if((record as IUIKitViewSubmitIncomingInteraction).view) {
+        const testAssociation = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, (record as IUIKitViewSubmitIncomingInteraction).view.id);
+        const [test] = await read.getPersistenceReader().readByAssociation(testAssociation) as Array<IModalContext>;
+        record.threadId = test.threadId;
+        record.room = test.room;
+        // Extract anonymous options before state is modified
+        anonymousOptions = state.mixedVisibility.anonymousOptions
+        state = (record as IUIKitViewSubmitIncomingInteraction).view.state;
+    }
 
     if (!state.poll || !state.poll.question || state.poll.question.trim() === '') {
         throw { question: 'Please type your question here' };
@@ -72,12 +85,13 @@ export async function createPollMessage(data: IUIKitViewSubmitIncomingInteractio
             options,
             totalVotes: 0,
             votes: options.map(() => ({ quantity: 0, voters: [] })),
-            confidential: visibility === 'confidential',
+            visibility: visibility,
             singleChoice: mode === 'single',
+            anonymousOptions
         };
 
         const block = modify.getCreator().getBlockBuilder();
-        createPollBlocks(block, poll.question, options, poll, showNames.value);
+        createPollBlocks(block, poll.question, options, poll, showNames.value, poll.anonymousOptions);
 
         builder.setBlocks(block);
 

--- a/src/lib/createPollModal.ts
+++ b/src/lib/createPollModal.ts
@@ -75,6 +75,10 @@ export async function createPollModal({ id = '', question, persistence, data, mo
                             text: block.newPlainTextObject('Confidential vote'),
                             value: 'confidential',
                         },
+                        {
+                            text: block.newPlainTextObject('Mixed Visibility vote'),
+                            value: 'mixed',
+                        },
                     ],
                 }),
             ],

--- a/src/lib/createPollModal.ts
+++ b/src/lib/createPollModal.ts
@@ -2,7 +2,7 @@ import { IModify, IPersistence } from '@rocket.chat/apps-engine/definition/acces
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from '@rocket.chat/apps-engine/definition/metadata';
 import { IUIKitModalViewParam } from '@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder';
 
-import { IModalContext } from '../definition';
+import { IModalContext, pollVisibility } from '../definition';
 import { uuid } from './uuid';
 
 export async function createPollModal({ id = '', question, persistence, data, modify, options = 2 }: {
@@ -65,19 +65,19 @@ export async function createPollModal({ id = '', question, persistence, data, mo
                 block.newStaticSelectElement({
                     placeholder: block.newPlainTextObject('Open vote'),
                     actionId: 'visibility',
-                    initialValue: 'open',
+                    initialValue: pollVisibility.open,
                     options: [
                         {
                             text: block.newPlainTextObject('Open vote'),
-                            value: 'open',
+                            value: pollVisibility.open,
                         },
                         {
                             text: block.newPlainTextObject('Confidential vote'),
-                            value: 'confidential',
+                            value: pollVisibility.confidential,
                         },
                         {
                             text: block.newPlainTextObject('Mixed Visibility vote'),
-                            value: 'mixed',
+                            value: pollVisibility.mixed,
                         },
                     ],
                 }),

--- a/src/lib/createPollModal.ts
+++ b/src/lib/createPollModal.ts
@@ -13,7 +13,7 @@ export async function createPollModal({ id = '', question, persistence, data, mo
     modify: IModify,
     options?: number,
 }): Promise<IUIKitModalViewParam> {
-    const viewId = id || uuid();
+    const viewId = id || `create-poll-modal-${uuid()}`;
 
     const association = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, viewId);
     await persistence.createWithAssociation(data, association);

--- a/src/lib/finishPollMessage.ts
+++ b/src/lib/finishPollMessage.ts
@@ -47,7 +47,7 @@ export async function finishPollMessage({ data, read, persistence, modify }: {
 
         const showNames = await read.getEnvironmentReader().getSettings().getById('use-user-name');
 
-        createPollBlocks(block, poll.question, poll.options, poll, showNames.value);
+        createPollBlocks(block, poll.question, poll.options, poll, showNames.value, poll.anonymousOptions);
 
         message.setBlocks(block);
 

--- a/src/lib/votePoll.ts
+++ b/src/lib/votePoll.ts
@@ -35,7 +35,7 @@ export async function votePoll({ data, read, persistence, modify }: {
 
     const showNames = await read.getEnvironmentReader().getSettings().getById('use-user-name');
 
-    createPollBlocks(block, poll.question, poll.options, poll, showNames.value);
+    createPollBlocks(block, poll.question, poll.options, poll, showNames.value, poll.anonymousOptions);
 
     message.setBlocks(block);
 


### PR DESCRIPTION
- IPoll interface's `confidential?: boolean` property updated to `visibility?: string`.
-  Added `anonymousOptions: Array<string>` property to IPoll interface.
- Mixed Visibility modal with MultiStaticSelectElement pops open when poll creator chooses "Mixed Visibility vote".
- Makes mixed visibility stay consistent on finishing poll and when users cast votes.
- Allows mixed visibility polls to be created within threads.
- Shows anonymous marked responses as voted by "Anonymous" user.


https://user-images.githubusercontent.com/28918901/123508369-95af6f00-d68c-11eb-9e2b-afe63280a32b.mp4



Closes #4 